### PR TITLE
added options and fixed bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # flake8_private_name_import
-flake8 plugin that reports imports of private names
+flake8 plugin that reports imports of private names. 
+
+# documentation is soon
+I will prepare documentation for the plugin soon but for now you may check 
+[tests](https://github.com/rows-s/flake8_private_name_import/blob/master/flake8_private_name_import_test.py).
+They have examples of what it will report and what options are available, and they are easy to read:
+```python
+    TestCase(
+        'from module.sub_module import _function, _variable',
+        {
+            '1:0: PNI001 found import of private name: _function',
+            '1:0: PNI001 found import of private name: _variable',
+        },
+    ),
+```

--- a/flake8_private_name_import.py
+++ b/flake8_private_name_import.py
@@ -1,52 +1,104 @@
+import argparse
 import ast
 import re
-from itertools import chain
-from typing import Any, Generator, Iterator, List, Tuple, Type
+from functools import partial
+from typing import Any, Iterator, List, Tuple, Type
 
-SKIP_NAMES = ('__future__',)
-TEST_PATH_PATTERN = re.compile('/test|test[/.]')  # directory or file name starts or ends with 'test'
+from flake8.options.manager import OptionManager
+
+
+TEST_PATH_PATTERN = re.compile('/(py)?test|test[/.]')  # directory or file name starts or ends with 'test' or 'pytest'
 
 
 class Visitor(ast.NodeVisitor):
-    def __init__(self, tree: ast.AST, file_name: str) -> None:
-        self.tree = tree
-        self.file_name = file_name
+    def __init__(self, plugin: 'Plugin') -> None:
         self.reports: List[Tuple[int, int, str]] = []
+        self.plugin = plugin
 
     def run(self) -> Iterator[Tuple[int, int, str]]:
-        if TEST_PATH_PATTERN.search(self.file_name):
+        if self.plugin.skip_test and TEST_PATH_PATTERN.search(self.plugin.file_name):
             return
-        self.visit(self.tree)
+        self.visit(self.plugin.tree)
         yield from iter(self.reports)
 
     def visit_Import(self, node: ast.Import) -> None:
-        self._report_names(
-            line_num=node.lineno,
-            col_num=node.col_offset,
-            names=chain.from_iterable(alias.name.split('.') for alias in node.names)
-        )
+        for alias in node.names:
+            self._report_private_module(alias.name, line_num=node.lineno, col_num=node.col_offset)
+
+    def _report_private_module(self, module: str, *, line_num: int, col_num: int) -> None:
+        is_private = module.startswith('_') or '._' in module
+        is_dunder = module.startswith('__') and module.endswith('__')
+        if is_private and not is_dunder and module not in self.plugin.skip_modules:
+            self.reports.append((line_num, col_num, f'PNI002 found import of private module: {module}'))
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        self._report_names(
-            line_num=node.lineno,
-            col_num=node.col_offset,
-            names=chain(node.module.split('.'), (alias.name for alias in node.names))
-        )
+        if node.level > 0 and self.plugin.skip_relative:
+            return
 
-    def _report_names(self, line_num: int, col_num: int, names: Iterator[str]) -> None:
-        self.reports.extend(
-            (line_num, col_num, f'PNI001 found import of private name: {name}')
-            for name in names
-            if name.startswith('_') and name not in SKIP_NAMES
-        )
+        module_path = '.' * node.level + (node.module or '')
+        self._report_private_module(module_path, line_num=node.lineno, col_num=node.col_offset)
+
+        for alias in node.names:
+            self._report_private_name(alias.name, line_num=node.lineno, col_num=node.col_offset)
+
+    def _report_private_name(self, name: str, *, line_num: int, col_num: int) -> None:
+        if name.startswith('_') and not name.endswith('_') and name not in self.plugin.skip_names:
+            self.reports.append((line_num, col_num, f'PNI001 found import of private name: {name}'))
 
 
 class Plugin:
     name = __name__
-    version = '0.1.3'
+    version = '0.1.4'
+
+    skip_names = {}
+    skip_modules = {}
+    skip_relative = False
+    skip_test = True
+
+    @staticmethod
+    def add_options(parser: OptionManager) -> None:
+        add_option = partial(parser.add_option, parse_from_config=True)
+        add_option(
+            '--private-name-import-skip-names',
+            dest='private_name_import_skip_names',
+            comma_separated_list=True,
+            help=(
+                'Comma separated private names import of which must not be reported.\n'
+                'Example: --private-name-import-skip-names=_my_func,_MyClass'
+            ),
+        )
+        add_option(
+            '--private-name-import-skip-modules',
+            dest='private_name_import_skip_modules',
+            comma_separated_list=True,
+            parse_from_config=True,
+        )
+        add_option(
+            '--private-name-import-skip-relative',
+            dest='private_name_import_skip_relative',
+            action='store_true',
+            default=False,
+            help='Allow import private name when import is relative (from .utils import _private_util)'
+        )
+        add_option(
+            '--private-name-import-dont-skip-test',
+            dest='private_name_import_dont_skip_test',
+            action='store_true',
+            default=False,
+            help='By default, imports of private names in test directories/files are not reported.\n'
+                 'With this option they will be reported.'
+        )
+
+    @classmethod
+    def parse_options(cls, options: argparse.Namespace) -> None:
+        cls.skip_names = set(options.private_name_import_skip_names)
+        cls.skip_modules = set(options.private_name_import_skip_modules)
+        cls.skip_relative = options.private_name_import_skip_relative
+        cls.skip_test = not options.private_name_import_dont_skip_test
 
     def __init__(self, tree: ast.AST, filename: str) -> None:
-        self._visitor = Visitor(tree=tree, file_name=filename)
+        self.tree = tree
+        self.file_name = filename
 
-    def run(self) -> Generator[Tuple[int, int, str, Type[Any]], None, None]:
-        yield from ((line_num, col_num, msg, type(self)) for line_num, col_num, msg in self._visitor.run())
+    def run(self) -> Iterator[Tuple[int, int, str, Type[Any]]]:
+        yield from ((line_num, col_num, msg, type(self)) for line_num, col_num, msg in Visitor(self).run())

--- a/flake8_private_name_import_test.py
+++ b/flake8_private_name_import_test.py
@@ -1,23 +1,22 @@
 import ast
 import dataclasses
-from functools import partial
 from itertools import chain
 from typing import ClassVar, Iterator, Set
 
 import pytest
+from flake8.options.manager import OptionManager
 
 from flake8_private_name_import import Plugin
 
+DEFAULT_CONFIG_STR = (
+    '--private-name-import-skip-names=_function_skip,_variable_skip '
+    '--private-name-import-skip-modules=_module_skip,module._sub_module_skip'
+)
+DONT_SKIP_TEST_CONFIG_STR = DEFAULT_CONFIG_STR + ' --private-name-import-dont-skip-test'
+SKIP_RELATIVE_CONFIG_STR = DEFAULT_CONFIG_STR + ' --private-name-import-skip-relative'
 
-@dataclasses.dataclass(frozen=True)
-class PluginResult:
-    line_num: int
-    col_num: int
-    code: str
-    reported_name: str
-
-
-PNI001 = partial(PluginResult, code='PNI001')
+CONFIG_PARSER = OptionManager(version='does_not_work_without_some_str_value')
+Plugin.add_options(CONFIG_PARSER)
 
 
 @dataclasses.dataclass
@@ -25,76 +24,112 @@ class TestCase:
     __test__: ClassVar[bool] = False
 
     code: str
+    reports: Set[str] = dataclasses.field(default_factory=set)
     file_name: str = './main.py'
-    expected_results: Set[PluginResult] = dataclasses.field(default_factory=set)
+    config_str: str = DEFAULT_CONFIG_STR
 
 
 VALID_CASES = (
-    TestCase(code='import module'),
-    TestCase(code='import module.sub_module'),
-    TestCase(code='from module import allowed_name'),
-    TestCase(code='from module.sub_module import allowed_name'),
-    TestCase(code='from module.sub_module import allowed_name, allowed_name2'),
-    TestCase(code='from module.sub_module import (\nallowed_name,\nallowed_name2\n)'),
-    TestCase(code='from module.sub_module import \\\nallowed_name,\\\nallowed_name2'),
-)
-
-SKIP_CASES = (
-    TestCase(code='from __future__ import annotations'),
-    TestCase(code='import _private', file_name='./main_test.py'),
-    TestCase(code='import _private', file_name='./test_main.py'),
-    TestCase(code='import _private', file_name='./main_test/conf.py'),
-    TestCase(code='import _private', file_name='./test_main/conf.py'),
+    TestCase('import module'),
+    TestCase('import module.sub_module'),
+    TestCase('from module import function'),
+    TestCase('from module.sub_module import function'),
+    TestCase('from module.sub_module import function, variable'),
+    TestCase('from . import function'),
+    TestCase('from .module import function'),
 )
 
 INVALID_CASES = (
     TestCase(
-        code='import _module',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_module')},
+        'import _module',
+        {'1:0: PNI002 found import of private module: _module'},
     ),
     TestCase(
-        code='import module._sub_module',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_sub_module')},
+        'import module._sub_module',
+        {'1:0: PNI002 found import of private module: module._sub_module'},
     ),
     TestCase(
-        code='import _module._sub_module',
-        expected_results={
-            PNI001(line_num=1, col_num=0, reported_name='_module'),
-            PNI001(line_num=1, col_num=0, reported_name='_sub_module'),
+        'from module import _function',
+        {'1:0: PNI001 found import of private name: _function'},
+    ),
+    TestCase(
+        'from module.sub_module import _function',
+        {'1:0: PNI001 found import of private name: _function'},
+    ),
+    TestCase(
+        'from module.sub_module import function, _variable',
+        {'1:0: PNI001 found import of private name: _variable'},
+    ),
+    TestCase(
+        'from module.sub_module import _function, _variable',
+        {
+            '1:0: PNI001 found import of private name: _function',
+            '1:0: PNI001 found import of private name: _variable',
         },
     ),
     TestCase(
-        code='from module import _private',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_private')},
-    ),
-    TestCase(
-        code='from module.sub_module import _private',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_private')},
-    ),
-    TestCase(
-        code='from module.sub_module import name, _private',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_private')},
-    ),
-    TestCase(
-        code='from module.sub_module import (\nallowed_name,\n_private\n)',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_private')},
-    ),
-    TestCase(
-        code='from module.sub_module import \\\nallowed_name,\\\n_private',
-        expected_results={PNI001(line_num=1, col_num=0, reported_name='_private')},
-    ),
-    TestCase(
-        code='\n\nimport _module',
-        expected_results={PNI001(line_num=3, col_num=0, reported_name='_module')},
+        'import _module\nimport module\nimport module._sub_module',
+        {
+            '1:0: PNI002 found import of private module: _module',
+            '3:0: PNI002 found import of private module: module._sub_module',
+        },
     ),
 )
 
+SKIP_CASES = (
+    TestCase('from __custom__ import annotations'),  # dunder is not treated as private
+    TestCase('import _module', file_name='./main_test.py'),  # skip if FILE ENDS with 'test'
+    TestCase('import _module', file_name='./test_main.py'),  # skip if FILE STARTS with 'test'
+    TestCase('import _module', file_name='./pytest_main.py'),  # skip if FILE STARTS with 'pytest'
+    TestCase('import _module', file_name='./main_test/conf.py'),  # skip if DIR ENDS with 'test'
+    TestCase('import _module', file_name='./test_main/conf.py'),  # skip if DIR STARTS with 'test'
+    TestCase('import _module', file_name='./pytest_main/conf.py'),  # skip if DIR STARTS with 'pytest'
+    TestCase('import _module_skip', file_name='./pytest_main/conf.py'),  # config says to skip the module
+    TestCase('import _sub_module_skip', file_name='./pytest_main/conf.py'),  # config says to skip the module
+    TestCase('from module import _function_skip', file_name='./pytest_main/conf.py'),  # config says to skip the name
+    TestCase('from module import _variable_skip', file_name='./pytest_main/conf.py'),  # config says to skip the name
+    # config says to skip relative
+    TestCase('from .module._sub_module import _private', config_str=SKIP_RELATIVE_CONFIG_STR),
+)
 
-@pytest.mark.parametrize('test_case', chain(VALID_CASES, SKIP_CASES, INVALID_CASES))
+ALMOST_SKIP_CASES = (
+    TestCase(
+        'import _module',
+        {'1:0: PNI002 found import of private module: _module'},
+        file_name='./not_test_conf.py',  # test in the middle of file name is not treated as test
+     ),
+    TestCase(
+        'import _module',
+        {'1:0: PNI002 found import of private module: _module'},
+        file_name='./not_test_dir/conf.py',  # test in the middle of dir name is not treated as test
+     ),
+    TestCase(
+        'import _module',
+        {'1:0: PNI002 found import of private module: _module'},
+        file_name='./main_test.py',  # config says to not skip test files
+        config_str=DONT_SKIP_TEST_CONFIG_STR,
+     ),
+    TestCase(
+        'from .module import _private',  # config does not say to skip relative
+        {'1:0: PNI001 found import of private name: _private'},
+     ),
+)
+
+CONFIG_PARSER = OptionManager(version='whatever')
+Plugin.add_options(CONFIG_PARSER)
+
+
+@pytest.mark.parametrize('test_case', chain(VALID_CASES, INVALID_CASES, SKIP_CASES, ALMOST_SKIP_CASES))
 def test_plugin(test_case: TestCase):
-    assert set(_run_plugin(test_case)) == test_case.expected_results
+    assert set(_get_plugin_reports(test_case)) == test_case.reports
 
 
-def _run_plugin(test_case: TestCase) -> Iterator[PluginResult]:
+def _get_plugin_reports(test_case: TestCase) -> Iterator[str]:
+    Plugin.parse_options(CONFIG_PARSER.parse_args(test_case.config_str.split())[0])
     for line_num, col_num, msg, _ in Plugin(ast.parse(test_case.code), test_case.file_name).run():
-        yield PluginResult(line_num=line_num, col_num=col_num, code=msg[:6], reported_name=msg.split(': ')[1])
+        yield f'{line_num}:{col_num}: {msg}'
+
+
+def test_empty_config():
+    """add_options must specify all options with a default value"""
+    Plugin.parse_options(CONFIG_PARSER.parse_args([])[0])  # test is valid while `parse_options` accesses all attributes

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='flake8_private_name_import',
-    version='0.1.3',
+    version='0.1.4',
     description="flake8 plugin that reports imports of private names",
     long_description="flake8 plugin that reports imports of private names",
     # Get more from https://pypi.org/classifiers/
@@ -43,7 +43,7 @@ setup(
     },
     entry_points={
         'flake8.extension': [
-            'PNI001 = flake8_private_name_import:Plugin',
+            'PNI00 = flake8_private_name_import:Plugin',
         ],
     },
 )


### PR DESCRIPTION
Fixes #3

Added options:
`--private-name-import-skip-names` - Comma separated private names import of which must not be reported.
`--private-name-import-skip-modules` - Comma separated private modules import of which must not be reported.
`--private-name-import-skip-relative` - Allow import private name when import is relative (from .utils import _private_util)
`--private-name-import-dont-skip-test` - By default, imports of private names in test directories/files are not reported. This option turn the feature off (test files and directories will be checked for private imports).