### PR TITLE
Adds options; more code will be checked; added tests;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # flake8_private_name_import
 flake8 plugin that reports imports of private names. 
 
-# codes
+# Codes
 
 <details>
   <summary>PNI001 found import of private name: {name}</summary>
@@ -31,7 +31,7 @@ flake8 plugin that reports imports of private names.
 
 # Options
 
-### Skip names (PNI001)
+### Skip names (`PNI001`)
 
 `console`: --private-name-import-skip-names  
 `config_file`: private_name_import_skip_names  
@@ -67,7 +67,7 @@ If plain name used then name would be skipped independent on module it imported 
   ```
 </details>
 
-### Skip modules (PNI002)
+### Skip modules (`PNI002`)
 
 `console`: --private-name-import-skip-modules  
 `config_file`: private_name_import_skip_modules  
@@ -89,7 +89,7 @@ Affects only imports of modules, imports of names from those modules will be rep
   ```
 </details>
 
-### Skip names from modules (PNI003, PNI001)
+### Skip names from modules (`PNI003`, `PNI001`)
 
 `console`: --private-name-import-skip-names-from-modules  
 `config_file`: private_name_import_skip_names_from_modules  
@@ -136,7 +136,7 @@ When option used, relative imports will not be reported
 By default, imports in test directories/files are not reported.  
 This option turn the feature off (test files and folders will be checked for private imports).
 
-### Skip test files and folders
+### Skip `TYPE_CHECKING`
 
 `console`: --private-name-import-dont-skip-type-checking  
 `config_file`: private_name_import_dont_skip_type_checking  

--- a/README.md
+++ b/README.md
@@ -1,16 +1,146 @@
 # flake8_private_name_import
 flake8 plugin that reports imports of private names. 
 
-# documentation is soon
-I will prepare documentation for the plugin soon but for now you may check 
-[tests](https://github.com/rows-s/flake8_private_name_import/blob/master/flake8_private_name_import_test.py).
-They have examples of what it will report and what options are available, and they are easy to read:
-```python
-    TestCase(
-        'from module.sub_module import _function, _variable',
-        {
-            '1:0: PNI001 found import of private name: _function',
-            '1:0: PNI001 found import of private name: _variable',
-        },
-    ),
-```
+# codes
+
+<details>
+  <summary>PNI001 found import of private name: {name}</summary>
+
+  ```python
+  from module import _my_private_name  # PNI001 found import of private name: _my_private_name
+  ```
+</details>
+
+<details>
+  <summary>PNI002 found import of private module: {module}</summary>
+
+  ```python
+  import _module  # PNI002 found import of private module: _module
+  import module._sub_module  # PNI002 found import of private module: module._sub_module
+  ```
+</details>
+
+<details>
+  <summary>PNI003 found import from private module: {module}</summary>
+
+  ```python
+  from _module import name  # PNI003 found import from private module: _module
+  from module._sub_module import name  # PNI003 found import from private module: module._sub_module
+  ```
+</details>
+
+# Options
+
+### Skip names (PNI001)
+
+`console`: --private-name-import-skip-names  
+`config_file`: private_name_import_skip_names  
+`type`: comma separated list (list for config_file)
+
+Private names import of which must not be reported.  
+Accepts full path (`module.sub_module._name`) or plain name (`_name`).  
+If full path used then only that name from that module would be skipped.  
+If plain name used then name would be skipped independent on module it imported from.
+
+<details>
+  <summary>Example (specific name from specific module)</summary>
+  
+  ```
+  flake8 --private-name-import-skip-names=module.sub_module._function,module.sub_module._Class
+  ```
+  ```python
+  from module.sub_module import _function, _Class  # both skipped
+  from module.sub_module import _CONSTANT  # PNI001 found import of private name: _CONSTANT
+  ```
+</details>
+
+<details>
+  <summary>Example (module independent name)</summary>
+  
+  ```
+  flake8 --private-name-import-skip-names=_function,_Class
+  ```
+  ```python
+  from module import _function, _Class  # both skipped
+  from module.sub_module import _function, _Class  # both skipped
+  from module.sub_module import _CONSTANT  # PNI001 found import of private name: _CONSTANT
+  ```
+</details>
+
+### Skip modules (PNI002)
+
+`console`: --private-name-import-skip-modules  
+`config_file`: private_name_import_skip_modules  
+`type`: comma separated list (list for config_file)
+ 
+Private modules import of which must not be reported.  
+Affects only imports of modules, imports of names from those modules will be reported.
+
+<details>
+  <summary>Example</summary>
+  
+  ```
+  flake8 --private-name-import-skip-modules=_module,module._sub_module
+  ```
+  ```python
+  import _module  # skipped
+  import module._sub_module  # skipped
+  from _module import name  # PNI003 found import from private module: _module
+  ```
+</details>
+
+### Skip names from modules (PNI003, PNI001)
+
+`console`: --private-name-import-skip-names-from-modules  
+`config_file`: private_name_import_skip_names_from_modules  
+`type`: comma separated list (list for config_file)
+ 
+Comma separated modules imports of private names from which must not be reported.  
+Affects only imports of names from those modules, imports of modules will be reported.
+
+<details>
+  <summary>Example</summary>
+  
+  ```
+  flake8 --private-name-import-skip-names-from-modules=_module,module._sub_module
+  ```
+  ```python
+  from _module import name  # skipped
+  from module._sub_module import _name  # skipped (both private module and private name)
+  import _module  # PNI002 found import of private module: _module
+  ```
+</details>
+
+### Skip local imports
+
+`console`: --private-name-import-skip-local  
+`config_file`: private_name_import_skip_local  
+`type`: flag
+ 
+When option used, import inside functions will not be reported
+
+### Skip relative imports
+
+`console`: --private-name-import-skip-relative  
+`config_file`: private_name_import_skip_relative  
+`type`: flag
+ 
+When option used, relative imports will not be reported
+
+### Skip test files and folders
+
+`console`: --private-name-import-dont-skip-test  
+`config_file`: private_name_import_dont_skip_test  
+`type`: flag
+ 
+By default, imports in test directories/files are not reported.  
+This option turn the feature off (test files and folders will be checked for private imports).
+
+### Skip test files and folders
+
+`console`: --private-name-import-dont-skip-type-checking  
+`config_file`: private_name_import_dont_skip_type_checking  
+`type`: flag
+ 
+By default, imports under `TYPE_CHECKING` are not reported.  
+This option turn the feature off (`TYPE_CHECKING` imports will be checked for private imports).

--- a/flake8_private_name_import.py
+++ b/flake8_private_name_import.py
@@ -1,59 +1,132 @@
 import argparse
 import ast
 import re
+from collections import deque
 from functools import partial
-from typing import Any, Iterator, List, Tuple, Type
+from itertools import chain
+from typing import Any, Dict, Iterator, Set, Tuple, Type
 
 from flake8.options.manager import OptionManager
-
 
 TEST_PATH_PATTERN = re.compile('/(py)?test|test[/.]')  # directory or file name starts or ends with 'test' or 'pytest'
 
 
-class Visitor(ast.NodeVisitor):
+def is_type_checking_node(node: ast.If) -> bool:
+    """returns True if the If-node tests TYPE_CHECKING"""
+    return isinstance(node.test, ast.Name) and node.test.id == 'TYPE_CHECKING'
+
+
+def is_private_name(name: str, is_module: bool = False) -> bool:
+    """
+    returns True if the name is private
+
+    :param is_module: If True also checks each dot-separated module
+    """
+    return (
+        (name.startswith('_') or is_module and '._' in name)
+        and not (name.startswith('__') and name.endswith('__'))
+    )
+
+
+class Visitor:
+    """
+    Acts almost like ast.NodeVisitor.
+    But instead of recursive calls uses loop over stack.
+    """
+    CLASS_AND_FUNC_NODE_TYPES = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+    IMPORT_NODE_TYPES = (ast.Import, ast.ImportFrom)
+
     def __init__(self, plugin: 'Plugin') -> None:
-        self.reports: List[Tuple[int, int, str]] = []
         self.plugin = plugin
 
     def run(self) -> Iterator[Tuple[int, int, str]]:
+        """
+        visit nodes and yield reports
+
+        :return: Iterator of (line_number, column_number, report_message)
+        """
         if self.plugin.skip_test and TEST_PATH_PATTERN.search(self.plugin.file_name):
             return
-        self.visit(self.plugin.tree)
-        yield from iter(self.reports)
 
-    def visit_Import(self, node: ast.Import) -> None:
+        # stack contains nodes that are not configured to be skipped
+        # contains module-level imports, even imports under if-else-statement (always)
+        # contains TYPE_CHECKING imports (if not skip_type_checking)
+        # contains class and func defs (if not skip_local)
+        # contains class-level and func-level imports (only first-indent imports and if not skip_local)
+        stack = deque(
+            node
+            for node in self.plugin.tree.body
+            if isinstance(node, self.IMPORT_NODE_TYPES)
+            or (not self.plugin.skip_local and isinstance(node, self.CLASS_AND_FUNC_NODE_TYPES))
+            or isinstance(node, ast.If) and (not self.plugin.skip_type_checking or not is_type_checking_node(node))
+        )
+
+        while stack:
+            node = stack.pop()
+            if isinstance(node, ast.Import):
+                yield from self.check_import(node)
+            elif isinstance(node, ast.ImportFrom):
+                yield from self.check_from_import(node)
+            else:
+                sub_nodes = chain(node.body, (node.orelse if isinstance(node, ast.If) else ()))
+                stack.extend(
+                    sub_node
+                    for sub_node in sub_nodes
+                    if isinstance(sub_node, self.IMPORT_NODE_TYPES)
+                    or isinstance(sub_node, self.CLASS_AND_FUNC_NODE_TYPES)
+                )
+
+    def check_import(self, node: ast.Import) -> Iterator[Tuple[int, int, str]]:
+        """
+        Check ast.Import and yield reports
+
+        :return: Iterator of (line_number, column_number, report_message)
+        """
         for alias in node.names:
-            self._report_private_module(alias.name, line_num=node.lineno, col_num=node.col_offset)
+            if is_private_name(alias.name, is_module=True) and alias.name not in self.plugin.skip_modules:
+                yield node.lineno, node.col_offset, f'PNI002 found import of private module: {alias.name}'
 
-    def _report_private_module(self, module: str, *, line_num: int, col_num: int) -> None:
-        is_private = module.startswith('_') or '._' in module
-        is_dunder = module.startswith('__') and module.endswith('__')
-        if is_private and not is_dunder and module not in self.plugin.skip_modules:
-            self.reports.append((line_num, col_num, f'PNI002 found import of private module: {module}'))
+    def check_from_import(self, node: ast.ImportFrom) -> None:
+        """
+        Check ast.ImportFrom and yield reports
 
-    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
-        if node.level > 0 and self.plugin.skip_relative:
+        :return: Iterator of (line_number, column_number, report_message)
+        """
+        module = '.' * node.level + (node.module or '')
+
+        if node.level > 0 and self.plugin.skip_relative or module in self.plugin.skip_from_modules:
             return
+        if is_private_name(module, is_module=True):
+            yield node.lineno, node.col_offset, f'PNI003 found import from private module: {module}'
 
-        module_path = '.' * node.level + (node.module or '')
-        self._report_private_module(module_path, line_num=node.lineno, col_num=node.col_offset)
+        module_skip_names = self.plugin.module_to_skip_names.get(module, set())
 
         for alias in node.names:
-            self._report_private_name(alias.name, line_num=node.lineno, col_num=node.col_offset)
-
-    def _report_private_name(self, name: str, *, line_num: int, col_num: int) -> None:
-        if name.startswith('_') and not name.endswith('_') and name not in self.plugin.skip_names:
-            self.reports.append((line_num, col_num, f'PNI001 found import of private name: {name}'))
+            name = alias.name
+            if is_private_name(name) and name not in self.plugin.global_skip_names and name not in module_skip_names:
+                yield node.lineno, node.col_offset, f'PNI001 found import of private name: {alias.name}'
 
 
 class Plugin:
     name = __name__
     version = '0.1.5'
 
-    skip_names = {}
-    skip_modules = {}
-    skip_relative = False
-    skip_test = True
+    global_skip_names: Set[str] = {}
+    """Names that must be skipped independent of module"""
+    skip_modules: Set[str] = {}
+    """Modules that must be skipped"""
+    skip_from_modules: Set[str] = {}
+    """Modules any name of which must be skipped"""
+    module_to_skip_names: Dict[str, Set[str]] = {}
+    """Modules to set of its names that must be skipped"""
+    skip_relative: bool = False
+    """Marks if relative imports must be skipped"""
+    skip_test: bool = True
+    """Marks if test directories/files must be skipped"""
+    skip_local: bool = False
+    """Marks if local imports must be skipped"""
+    skip_type_checking: bool = True
+    """Marks if imports under TYPE_CHECKING must be skipped"""
 
     @staticmethod
     def add_options(parser: OptionManager) -> None:
@@ -63,41 +136,86 @@ class Plugin:
             dest='private_name_import_skip_names',
             comma_separated_list=True,
             default=(),
-            help='Comma separated private names import of which must not be reported.'
+            help='Comma separated private names import of which must not be reported.\n'
+                 'Accepts full path (module.sub_module._name) or plain name (_name).\n'
+                 'If full path used then only that name from that module would be skipped.\n'
+                 'If plain name used then name would be skipped independent on module it imported from.'
         )
         add_option(
             '--private-name-import-skip-modules',
             dest='private_name_import_skip_modules',
             comma_separated_list=True,
             default=(),
-            help='Comma separated private modules import of which must not be reported.'
+            help='Comma separated private modules import of which must not be reported.\n'
+                 'Affects only imports of modules. Imports of names from those modules will be reported.'
+        )
+        add_option(
+            '--private-name-import-skip-names-from-modules',
+            dest='private_name_import_skip_names_from_modules',
+            comma_separated_list=True,
+            default=(),
+            help='Comma separated modules imports of private names from which must not be reported.'
+        )
+        add_option(
+            '--private-name-import-skip-local',
+            dest='private_name_import_skip_local',
+            action='store_true',
+            default=False,
+            help='When option used, import inside functions will not be reported'
         )
         add_option(
             '--private-name-import-skip-relative',
             dest='private_name_import_skip_relative',
             action='store_true',
             default=False,
-            help='Allow import private name when import is relative (from .utils import _private_util)'
+            help='When option used, relative imports will not be reported'
         )
         add_option(
             '--private-name-import-dont-skip-test',
             dest='private_name_import_dont_skip_test',
             action='store_true',
             default=False,
-            help='By default, imports of private names in test directories/files are not reported.\n'
+            help='By default, imports in test directories/files are not reported.\n'
                  'This option turn the feature off (test files and folders will be checked for private imports).'
+        )
+        add_option(
+            '--private-name-import-dont-skip-type-checking',
+            dest='private_name_import_dont_skip_type_checking',
+            action='store_true',
+            default=False,
+            help='By default, imports under TYPE_CHECKING are not reported.\n'
+                 'This option turn the feature off (TYPE_CHECKING imports will be checked for private imports).'
         )
 
     @classmethod
     def parse_options(cls, options: argparse.Namespace) -> None:
-        cls.skip_names = set(options.private_name_import_skip_names)
-        cls.skip_modules = set(options.private_name_import_skip_modules)
-        cls.skip_relative = options.private_name_import_skip_relative
+        """parse options and save them in class' attributes"""
+        cls.skip_type_checking = not options.private_name_import_dont_skip_type_checking
         cls.skip_test = not options.private_name_import_dont_skip_test
+        cls.skip_relative = options.private_name_import_skip_relative
+        cls.skip_local = options.private_name_import_skip_local
 
-    def __init__(self, tree: ast.AST, filename: str) -> None:
+        cls.skip_modules = set(options.private_name_import_skip_modules)
+        cls.skip_from_modules = set(options.private_name_import_skip_names_from_modules)
+
+        cls.global_skip_names = set()
+        cls.module_to_skip_names = {}
+        for name in options.private_name_import_skip_names:
+            try:  # module.sub_module._private_name
+                module, name = name.split('.', maxsplit=1)
+            except ValueError:  # _private_name
+                cls.global_skip_names.add(name)
+            else:
+                cls.module_to_skip_names.setdefault(module, set()).add(name)
+
+    def __init__(self, tree: ast.Module, filename: str) -> None:
         self.tree = tree
         self.file_name = filename
 
     def run(self) -> Iterator[Tuple[int, int, str, Type[Any]]]:
+        """
+        Entry point for flake8
+
+        :return: Iterator of (line_number, column_number, report_message, plugin_type)
+        """
         yield from ((line_num, col_num, msg, type(self)) for line_num, col_num, msg in Visitor(self).run())

--- a/flake8_private_name_import.py
+++ b/flake8_private_name_import.py
@@ -109,7 +109,7 @@ class Visitor:
 
 class Plugin:
     name = __name__
-    version = '0.1.5'
+    version = '1.0.0'
 
     global_skip_names: Set[str] = {}
     """Names that must be skipped independent of module"""

--- a/flake8_private_name_import_test.py
+++ b/flake8_private_name_import_test.py
@@ -1,7 +1,6 @@
 import ast
 import dataclasses
-from itertools import chain
-from typing import ClassVar, Iterator, Set
+from typing import ClassVar, Iterator, List, Set
 
 import pytest
 from flake8.options.manager import OptionManager
@@ -9,13 +8,16 @@ from flake8.options.manager import OptionManager
 from flake8_private_name_import import Plugin
 
 DEFAULT_CONFIG_STR = (
-    '--private-name-import-skip-names=_function_skip,_variable_skip '
-    '--private-name-import-skip-modules=_module_skip,module._sub_module_skip'
+    '--private-name-import-skip-names=_function_global_skip,module_for_skip_specific_name._function '
+    '--private-name-import-skip-modules=_module_skip,module._sub_module_skip '
+    '--private-name-import-skip-names-from-modules=_module_for_skip_all_names,module._sub_module_for_skip_all_names '
 )
-DONT_SKIP_TEST_CONFIG_STR = DEFAULT_CONFIG_STR + ' --private-name-import-dont-skip-test'
-SKIP_RELATIVE_CONFIG_STR = DEFAULT_CONFIG_STR + ' --private-name-import-skip-relative'
+SKIP_LOCAL_CONFIG_STR = DEFAULT_CONFIG_STR + '--private-name-import-skip-local'
+SKIP_RELATIVE_CONFIG_STR = DEFAULT_CONFIG_STR + '--private-name-import-skip-relative'
+DONT_SKIP_TEST_CONFIG_STR = DEFAULT_CONFIG_STR + '--private-name-import-dont-skip-test'
+DONT_SKIP_TYPE_CHECKING_CONFIG_STR = DEFAULT_CONFIG_STR + '--private-name-import-dont-skip-type-checking'
 
-CONFIG_PARSER = OptionManager(version='does_not_work_without_some_str_value')
+CONFIG_PARSER = OptionManager(version='does_not_work_without_str_value')
 Plugin.add_options(CONFIG_PARSER)
 
 
@@ -30,16 +32,21 @@ class TestCase:
 
 
 VALID_CASES = (
+    TestCase(''),  # empty file
     TestCase('import module'),
+    TestCase('import module as _module'),
     TestCase('import module.sub_module'),
     TestCase('from module import function'),
     TestCase('from module.sub_module import function'),
     TestCase('from module.sub_module import function, variable'),
     TestCase('from . import function'),
     TestCase('from .module import function'),
+    TestCase('from module import __custom__'),  # dunder name is not treated as private
+    TestCase('from __custom__ import function'),  # dunder module is not treated as private
+    TestCase('_variable = _function(_argument)'),  # usage of private names is not treated as import
 )
 
-INVALID_CASES = (
+REPORT_CASES = (
     TestCase(
         'import _module',
         {'1:0: PNI002 found import of private module: _module'},
@@ -57,71 +64,143 @@ INVALID_CASES = (
         {'1:0: PNI001 found import of private name: _function'},
     ),
     TestCase(
-        'from module.sub_module import function, _variable',
-        {'1:0: PNI001 found import of private name: _variable'},
+        'from module._sub_module import name',
+        {'1:0: PNI003 found import from private module: module._sub_module'},
     ),
-    TestCase(
-        'from module.sub_module import _function, _variable',
+    TestCase(  # code under global if-statements must be checked
+        'if sys.version_info == (3, 7):\n    import _module\nelse:\n    import _module',
+        {
+            '2:4: PNI002 found import of private module: _module',
+            '4:4: PNI002 found import of private module: _module',
+         },
+    ),
+    TestCase(  # all names must be checked
+        'from module.sub_module import function, _Class',
+        {'1:0: PNI001 found import of private name: _Class'},
+    ),
+    TestCase(  # all names must be reported
+        'from module.sub_module import _function, _Class',
         {
             '1:0: PNI001 found import of private name: _function',
-            '1:0: PNI001 found import of private name: _variable',
+            '1:0: PNI001 found import of private name: _Class',
         },
     ),
+)
+
+SKIP_CASES = (  # these names are skipped in DEFAULT_CONFIG_STR
+    # --private-name-import-skip-modules
+    TestCase('import _module_skip'),
+    TestCase('import module._sub_module_skip'),
+    # --private-name-import-skip-names-from-modules
+    TestCase('from _module_for_skip_all_names import _function, _Class'),
+    TestCase('from module._sub_module_for_skip_all_names import _function, _Class'),
+    # --private-name-import-skip-names
+    TestCase('from module import _function_global_skip'),
+    TestCase('from module_for_skip_specific_name import _function'),
+    TestCase(  # only specific name is skipped
+        'from module_for_skip_specific_name import _Class',
+        {'1:0: PNI001 found import of private name: _Class'}
+    ),
+)
+
+SKIP_TYPE_CHECKING_CASES = (
+    TestCase('if TYPE_CHECKING:\n    import _module'),  # config says to skip TYPE_CHECKING
+    TestCase(  # only global TYPE_CHECKING must be checked for private imports (if not skipped)
+        'def function():\n    if TYPE_CHECKING:\n        import _module',
+        config_str=DONT_SKIP_TYPE_CHECKING_CONFIG_STR,
+    ),
+    TestCase(  # config does not say to skip TYPE_CHECKING
+        'if TYPE_CHECKING:\n    import _module',
+        {'2:4: PNI002 found import of private module: _module'},
+        config_str=DONT_SKIP_TYPE_CHECKING_CONFIG_STR,
+    ),
+)
+
+CODE_WITH_LOCAL_IMPORTS = """\
+def function():
+    import _module  # local imports in functions are reported only if config says to
+    
+    if True:
+        import _module  # never reported; only first indent-level of functions is checked for imports 
+
+class MyClass:
+    def method(self):
+        import _module  # local imports in methods are reported only if config says to
+"""
+
+SKIP_LOCAL_CASES = (
+    TestCase(CODE_WITH_LOCAL_IMPORTS, config_str=SKIP_LOCAL_CONFIG_STR),  # config says to skip local imports
     TestCase(
-        'import _module\nimport module\nimport module._sub_module',
+        CODE_WITH_LOCAL_IMPORTS,
         {
-            '1:0: PNI002 found import of private module: _module',
-            '3:0: PNI002 found import of private module: module._sub_module',
+            '2:4: PNI002 found import of private module: _module',
+            '9:8: PNI002 found import of private module: _module',
+        },
+    )
+)
+
+
+SKIP_RELATIVE_CASES = (
+    TestCase('from . import _function', config_str=SKIP_RELATIVE_CONFIG_STR),
+    TestCase('from ._module import _function', config_str=SKIP_RELATIVE_CONFIG_STR),
+    TestCase('from ._module._sub_module import _function', config_str=SKIP_RELATIVE_CONFIG_STR),
+    TestCase(
+        'from ._module._sub_module import _function',
+        {
+            '1:0: PNI001 found import of private name: _function',
+            '1:0: PNI003 found import from private module: ._module._sub_module',
         },
     ),
 )
 
-SKIP_CASES = (
-    TestCase('from module import __custom__'),  # dunder is not treated as private
-    TestCase('from __custom__ import function'),  # dunder is not treated as private
-    TestCase('import _module', file_name='./main_test.py'),  # skip if FILE ENDS with 'test'
-    TestCase('import _module', file_name='./test_main.py'),  # skip if FILE STARTS with 'test'
-    TestCase('import _module', file_name='./pytest_main.py'),  # skip if FILE STARTS with 'pytest'
-    TestCase('import _module', file_name='./main_test/conf.py'),  # skip if DIR ENDS with 'test'
-    TestCase('import _module', file_name='./test_main/conf.py'),  # skip if DIR STARTS with 'test'
-    TestCase('import _module', file_name='./pytest_main/conf.py'),  # skip if DIR STARTS with 'pytest'
-    TestCase('import _module_skip', file_name='./pytest_main/conf.py'),  # config says to skip the module
-    TestCase('import _sub_module_skip', file_name='./pytest_main/conf.py'),  # config says to skip the module
-    TestCase('from module import _function_skip', file_name='./pytest_main/conf.py'),  # config says to skip the name
-    TestCase('from module import _variable_skip', file_name='./pytest_main/conf.py'),  # config says to skip the name
-    # config says to skip relative
-    TestCase('from .module._sub_module import _private', config_str=SKIP_RELATIVE_CONFIG_STR),
+
+def get_skip_test_path_cases() -> List[TestCase]:
+    test_cases = [
+        TestCase(  # 'test' in the middle of file name is not treated as test
+            'import _module',
+            {'1:0: PNI002 found import of private module: _module'},
+            file_name='./not_test_file.py',
+         ),
+        TestCase(  # 'test' in the middle of dir name is not treated as test
+            'import _module',
+            {'1:0: PNI002 found import of private module: _module'},
+            file_name='./not_test_dir/conf.py',
+         ),
+    ]
+
+    test_file_paths = (
+        *('./main_test.py', './test_main.py', './pytest_main.py'),   # test files
+        *('./main_test/conf.py', './test_main/conf.py', './pytest_main/conf.py'),  # test dirs
+    )
+    for file_path in test_file_paths:
+        test_cases.extend(
+            (
+                TestCase('import _module', file_name=file_path),
+                TestCase(
+                    'import _module',
+                    {'1:0: PNI002 found import of private module: _module'},
+                    file_name=file_path,
+                    config_str=DONT_SKIP_TEST_CONFIG_STR,
+                ),
+            )
+        )
+
+    return test_cases
+
+
+ALL_TEST_CASES = (
+    *VALID_CASES,
+    *REPORT_CASES,
+    *SKIP_CASES,
+    *SKIP_RELATIVE_CASES,
+    *SKIP_TYPE_CHECKING_CASES,
+    *SKIP_LOCAL_CASES,
+    *get_skip_test_path_cases(),
 )
 
-ALMOST_SKIP_CASES = (
-    TestCase(
-        'import _module',
-        {'1:0: PNI002 found import of private module: _module'},
-        file_name='./not_test_conf.py',  # test in the middle of file name is not treated as test
-     ),
-    TestCase(
-        'import _module',
-        {'1:0: PNI002 found import of private module: _module'},
-        file_name='./not_test_dir/conf.py',  # test in the middle of dir name is not treated as test
-     ),
-    TestCase(
-        'import _module',
-        {'1:0: PNI002 found import of private module: _module'},
-        file_name='./main_test.py',  # config says to not skip test files
-        config_str=DONT_SKIP_TEST_CONFIG_STR,
-     ),
-    TestCase(
-        'from .module import _private',  # config does not say to skip relative
-        {'1:0: PNI001 found import of private name: _private'},
-     ),
-)
 
-CONFIG_PARSER = OptionManager(version='whatever')
-Plugin.add_options(CONFIG_PARSER)
-
-
-@pytest.mark.parametrize('test_case', chain(VALID_CASES, INVALID_CASES, SKIP_CASES, ALMOST_SKIP_CASES))
-def test_plugin(test_case: TestCase):
+@pytest.mark.parametrize('test_case', ALL_TEST_CASES)
+def test_plugin_reports(test_case: TestCase):
     assert set(_get_plugin_reports(test_case)) == test_case.reports
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='flake8_private_name_import',
-    version='0.1.5',
+    version='1.0.0',
     description="flake8 plugin that reports imports of private names",
     long_description="flake8 plugin that reports imports of private names",
     # Get more from https://pypi.org/classifiers/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='flake8_private_name_import',
     version='1.0.0',
     description="flake8 plugin that reports imports of private names",
-    long_description="flake8 plugin that reports imports of private names",
+    long_description=open('README.txt').read(),
     # Get more from https://pypi.org/classifiers/
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes #5

# Visitor

Moved from `NodeVisitor` to custom implementation with loop over stack;
It was necessary to look inside nodes, but i don't like to use recursion for that;
Now its easier to realize what code would be checked;

# More code will be checked

Old realization did not check any imports except module-level imports.
Even imports under module-level `if-statement` was not processed (`if sys.version_info == ...`)

Now plugin checks module-level `if-statement`.  
But does not process nested `if-statement` (even `if-elif`).  
I aimed to cover cases where imports depend on python-version:
```python
if sys.version_info >= (3, 8):
    import importlib.metadata as importlib_metadata
else:
    import importlib_metadata
 ```
 
Also imports inside functions and methods will be checked:
```python
def function():
    import _module
    
class MyClass:
    def method(self):
        import _module
```

# new options 

```
--private-name-import-skip-names-from-modules=PRIVATE_NAME_IMPORT_SKIP_NAMES_FROM_MODULES
                        Comma separated modules imports of private names from
                        which must not be reported.
  --private-name-import-skip-local
                        When option used, import inside functions will not be
                        reported
  --private-name-import-dont-skip-type-checking
                        By default, imports under TYPE_CHECKING are not
                        reported. This option turn the feature off
                        (TYPE_CHECKING imports will be checked for private
                        imports).
```