### PR TITLE
migration back to NodeVisitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,51 +11,75 @@ And so you must avoid usage of internal interfaces finding another solution if i
 But if some member of your team do not follow the rule and keep importing internal names, 
 this plugin is probably what you are looking for.  
 
-# Where does plugin look for imports
-
-- Most of the time you would import name in top of the module.
-- Less of the time imports will be under if-else-statements (as example - `if sys.version_info`) 
-- Even less they will be placed in try-except blocks (`ImportError` usually)
-- But if package dependencies was broken into a circular imports, you will use them locally (within functions). 
-
-Trying to cover these cases, plugin looks for:
-- Module-level imports including `if-elif-else` and `try-except-else-finally` statements with any nesting-level.
-- Local imports, but only first-indent level of them, if import places in function and under an `if` it will be skipped.
-
 # Codes
 
 <details>
-  <summary>PNI001 found import of internal name: {name}</summary>
+  <summary>INI001 found import of internal name: {name}</summary>
 
   ```python
-  from module import _my_internal_name  # PNI001 found import of internal name: _my_internal_name
+  from module import _my_internal_name  # INI001 found import of internal name: _my_internal_name
   ```
 
 </details>
 
 <details>
-  <summary>PNI002 found import of internal module: {module}</summary>
+  <summary>INI002 found import of internal module: {module}</summary>
 
   ```python
-  import _module  # PNI002 found import of internal module: _module
-  import module._sub_module  # PNI002 found import of internal module: module._sub_module
+  import _module  # INI002 found import of internal module: _module
+  import module._sub_module  # INI002 found import of internal module: module._sub_module
   ```
 
 </details>
 
 <details>
-  <summary>PNI003 found import from internal module: {module}</summary>
+  <summary>INI003 found import from internal module: {module}</summary>
 
   ```python
-  from _module import name  # PNI003 found import from internal module: _module
-  from module._sub_module import name  # PNI003 found import from internal module: module._sub_module
+  from _module import name  # INI003 found import from internal module: _module
+  from module._sub_module import name  # INI003 found import from internal module: module._sub_module
   ```
 
 </details>
+
+# Plugin skips some code
+
+Skips test files:
+- It is often necessary to import internal name to properly test code.
+- It will never hurt you project if test fail after update of used internal interfaces.
+
+Skips TYPE_CHECKING:
+- It's fine to use internal names only for annotations.
+
+Plugin has optional skips:
+- [Relative imports](#skip-relative-imports)
+- [Local imports](#skip-local-imports)
+
+# How to deal with relative imports
+
+Plugin is not smart enough to realize that `from module.sub_module` and `from .sub_module` 
+are import from the same module and so if you skip imports from one module using [skip-names](#skip-names-ini001) or
+[skip-names-from-modules](#skip-names-from-modules-ini003-ini001) another import will be reported by Plugin.  
+It possible to make Plugin smart enough to realize that but for now it seems unnecessary because:
+- It must not be common case and developers should prefer absolute imports.
+- That knowledge would apply only for skips of names or modules but if it causes that much pain 
+  you would rather turn Plugin off for any relative imports.
+
+Imagine you have `utils` module that contains names which must be used only within that package,
+and so they marked as internal and imported as `from .utils import _name`.  
+And if you want to keep that strategy but also use the Plugin you have some options:
+- Skip names or module as they imported if you have not that many names or modules. 
+  And be aware that it applies for any modules with the same name and import depth: 
+  - `internal_name_import_skip_names = ['.utils._name']`
+  - `internal_name_import_skip_names_from_modules = ['.utils']`
+- Or skip relative import at all:
+  - `internal_name_import_skip_relative = true`
+- Do not use relative imports:
+  - Use linter to fix it for you. For example [absolufy-imports](https://github.com/MarcoGorelli/absolufy-imports) 
 
 # Options
 
-### Skip names (`PNI001`)
+### Skip names (`INI001`)
 
 `console`: --internal-name-import-skip-names  
 `config_file`: internal_name_import_skip_names  
@@ -78,7 +102,7 @@ Relative modules must be specified as they imported (`.module`, `..module`)
   ```python
   from module.sub_module import _function, _Class  # both skipped
   # `_CONSTANT` was not specified to be skipped from the module 
-  from module.sub_module import _CONSTANT  # PNI001 found import of internal name: _CONSTANT
+  from module.sub_module import _CONSTANT  # INI001 found import of internal name: _CONSTANT
   ```
 
 </details>
@@ -97,7 +121,7 @@ Relative modules must be specified as they imported (`.module`, `..module`)
 
 </details>
 
-### Skip modules (`PNI002`)
+### Skip modules (`INI002`)
 
 `console`: --internal-name-import-skip-modules  
 `config_file`: internal_name_import_skip_modules  
@@ -119,12 +143,12 @@ Relative modules must be specified as they imported (`.module`, `..module`)
   import _module  # skipped
   import module._sub_module  # skipped
   # but imports of names from the module will be reported
-  from _module import name  # PNI003 found import from internal module: _module
+  from _module import name  # INI003 found import from internal module: _module
   ```
 
 </details>
 
-### Skip names from modules (`PNI003`, `PNI001`)
+### Skip names from modules (`INI003`, `INI001`)
 
 `console`: --internal-name-import-skip-names-from-modules  
 `config_file`: internal_name_import_skip_names_from_modules  
@@ -144,7 +168,7 @@ Affects only imports of names from those modules, imports of modules will be rep
   from _module import name  # skipped
   from module._sub_module import _name  # skipped (both internal module and internal name)
   # but imports of the module will be reported
-  import _module  # PNI002 found import of internal module: _module
+  import _module  # INI002 found import of internal module: _module
   ```
 
 </details>
@@ -155,7 +179,7 @@ Affects only imports of names from those modules, imports of modules will be rep
 `config_file`: internal_name_import_skip_local  
 `type`: flag
  
-When option used, import inside functions will not be reported.
+When option used, import inside functions and methods will not be reported.
 
 ### Skip relative imports
 
@@ -164,11 +188,3 @@ When option used, import inside functions will not be reported.
 `type`: flag
 
 When option used, relative imports will not be reported.
-
-Plugin can't realize that `_module` and `._module` are the same module even if they are.
-If you skip one of them another will be reported.
-
-And it's common case when you have some in-package module 
-that shares internal names for in-package-only usage.  
-If you are in that case, you may either skip names and modules 
-or just disable plugin for relative imports. 

--- a/flake8_internal_name_import.py
+++ b/flake8_internal_name_import.py
@@ -1,125 +1,50 @@
 import argparse
 import ast
+import dataclasses
 import re
-from collections import deque
+from abc import ABC
 from functools import partial
-from itertools import chain
-from typing import Any, Dict, Iterator, Set, Tuple, Type
+from typing import Any, ClassVar, Dict, Iterator, List, Set, Tuple, Type, Union
 
 from flake8.options.manager import OptionManager
 
-TEST_PATH_PATTERN = re.compile('/(py)?test|test[/.]')  # directory or file name starts or ends with 'test' or 'pytest'
+
+@dataclasses.dataclass
+class INIXXX(ABC):
+    """Used for encapsulation of message generation and avoiding copy line_number, column_number duplicate access"""
+    BASE_MESSAGE: ClassVar[str]
+
+    node: Union[ast.Import, ast.ImportFrom]
+    message: str
+
+    @property
+    def full_message(self) -> str:
+        return f'{type(self).__name__} {self.BASE_MESSAGE}: {self.message}'
 
 
-def is_type_checking_node(node: ast.If) -> bool:
-    """returns True if the If-node tests TYPE_CHECKING"""
-    return isinstance(node.test, ast.Name) and node.test.id == 'TYPE_CHECKING'
+class INI001(INIXXX):
+    BASE_MESSAGE = 'found import of internal name'
 
 
-def is_internal_name(name: str, is_module: bool = False) -> bool:
-    """
-    returns True if the name is internal
+class INI002(INIXXX):
+    BASE_MESSAGE = 'found import of internal module'
 
-    :param is_module: If True also checks each dot-separated module
-    """
+
+class INI003(INIXXX):
+    BASE_MESSAGE = 'found import from internal module'
+
+
+def _is_internal_module_path(module_path: str) -> bool:
+    """returns True if module_path is internal such as '_module' or 'module._sub_module'"""
     return (
-        (name.startswith('_') or is_module and '._' in name)
-        and not (name.startswith('__') and name.endswith('__'))
+        module_path.startswith('_')
+        and not (module_path.startswith('__') and module_path.endswith('__'))
+        or '._' in module_path
     )
 
 
-class Visitor:
-    """
-    Acts almost like ast.NodeVisitor.
-    But instead of recursive calls uses loop over stack.
-    """
-    FUNC_NODE_CLASSES = (ast.FunctionDef, ast.AsyncFunctionDef)
-    CLASS_AND_FUNC_NODE_CLASSES = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
-    IMPORT_NODE_CLASSES = (ast.Import, ast.ImportFrom)
-    FUNCTION_NODE_CLASSES = (ast.Import, ast.ImportFrom)
-
-    def __init__(self, plugin: 'Plugin') -> None:
-        self.plugin = plugin
-
-    def run(self) -> Iterator[Tuple[int, int, str]]:
-        """
-        visit nodes and yield reports
-
-        :return: Iterator of (line_number, column_number, report_message)
-        """
-        if TEST_PATH_PATTERN.search(self.plugin.file_name):
-            return
-
-        stack: deque[ast.AST] = deque((self.plugin.tree,))
-
-        while stack:
-            node = stack.pop()
-            if isinstance(node, ast.Import):
-                yield from self.check_import(node)
-            elif isinstance(node, ast.ImportFrom):
-                yield from self.check_from_import(node)
-            else:
-                stack.extend(self._iter_sub_nodes(node))
-
-    def _iter_sub_nodes(self, node: ast.AST) -> Iterator[ast.AST]:
-        # plugin checks only first-indent level within functions (skips if, try, for, while, with and etc.)
-        # but checks nested functions;
-        # Note: visitor always starts with ast.Module and will face these nodes only if not `self.plugin.skip_local`
-        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-            extend_node_classes = (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
-        # both cases stand for module-level statements (if, try, and etc.); but first this excludes local
-        elif self.plugin.skip_local:
-            extend_node_classes = (ast.If, ast.Try)
-        else:
-            extend_node_classes = (ast.If, ast.Try, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
-
-        sub_nodes = chain(
-            (node.body if not (isinstance(node, ast.If) and is_type_checking_node(node)) else ()),
-            (node.orelse if isinstance(node, ast.If) else ()),
-            (node.finalbody if isinstance(node, ast.Try) else ()),
-            chain.from_iterable(sub_node.body for sub_node in node.handlers) if isinstance(node, ast.Try) else (),
-        )
-
-        yield from (
-            sub_node
-            for sub_node in sub_nodes
-            if isinstance(sub_node, (ast.Import, ast.ImportFrom)) or isinstance(sub_node, extend_node_classes)
-        )
-
-    def check_import(self, node: ast.Import) -> Iterator[Tuple[int, int, str]]:
-        """
-        Check ast.Import and yield reports
-
-        :return: Iterator of (line_number, column_number, report_message)
-        """
-        for alias in node.names:
-            if is_internal_name(alias.name, is_module=True) and alias.name not in self.plugin.skip_modules:
-                yield node.lineno, node.col_offset, f'PNI002 found import of internal module: {alias.name}'
-
-    def check_from_import(self, node: ast.ImportFrom) -> None:
-        """
-        Check ast.ImportFrom and yield reports
-
-        :return: Iterator of (line_number, column_number, report_message)
-        """
-        module = '.' * node.level + (node.module or '')
-
-        if node.level > 0 and self.plugin.skip_relative or module in self.plugin.skip_from_modules:
-            return
-        if is_internal_name(module, is_module=True):
-            yield node.lineno, node.col_offset, f'PNI003 found import from internal module: {module}'
-
-        module_skip_names = self.plugin.module_to_skip_names.get(module, set())
-
-        for alias in node.names:
-            name = alias.name
-            if is_internal_name(name) and name not in self.plugin.global_skip_names and name not in module_skip_names:
-                yield node.lineno, node.col_offset, f'PNI001 found import of internal name: {alias.name}'
-
-
-class Plugin:
-    name = __name__
-    version = '1.0.0'
+class Visitor(ast.NodeVisitor):
+    """Visits Nodes looking for imports of internal names"""
 
     global_skip_names: Set[str] = {}
     """Names that must be skipped independent of module"""
@@ -128,11 +53,59 @@ class Plugin:
     skip_from_modules: Set[str] = {}
     """Modules any name of which must be skipped"""
     module_to_skip_names: Dict[str, Set[str]] = {}
-    """Modules to set of its names that must be skipped"""
+    """Modules to set of its names that must be skipped: `{'module.sub_module': {'_name', 'name'}, ...}`"""
     skip_relative: bool = False
     """Marks if relative imports must be skipped"""
     skip_local: bool = False
     """Marks if local imports must be skipped"""
+
+    def __init__(self) -> None:
+        self.reports: List[INIXXX] = []
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """Check ast.Import and appends reports to `self.reports`"""
+        for alias in node.names:
+            if _is_internal_module_path(alias.name) and alias.name not in self.skip_modules:
+                self.reports.append(INI002(node=node, message=alias.name))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """Check ast.ImportFrom and appends reports to `self.reports`"""
+        module = '.' * node.level + (node.module or '')
+
+        if (
+            (node.level > 0 and self.skip_relative)
+            or module in self.skip_from_modules
+        ):
+            return
+
+        if _is_internal_module_path(module):
+            self.reports.append(INI003(node=node, message=module))
+
+        module_specific_skip_names = self.module_to_skip_names.get(module, set())
+        for name in (alias.name for alias in node.names):
+            if (
+                name.startswith('_')
+                and not (name.startswith('__') and name.endswith('__'))
+                and name not in self.global_skip_names
+                and name not in module_specific_skip_names
+            ):
+                self.reports.append(INI001(node=node, message=name))
+
+    def generic_visit(self, node: ast.AST) -> None:
+        """Extends default generic_visit with precondition to skip local imports or TYPE_CHECKING"""
+        if self.skip_local and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Name) and node.test.id == 'TYPE_CHECKING':
+            return
+        super().generic_visit(node)
+
+
+class Plugin:
+    name = __name__
+    version = '1.0.1'
+
+    # pattern of directory or file name that starts or ends with 'test' or 'pytest'
+    TEST_PATH_PATTERN: ClassVar[re.Pattern] = re.compile('/(py)?test|test[/.]')
 
     @staticmethod
     def add_options(parser: OptionManager) -> None:
@@ -144,7 +117,7 @@ class Plugin:
             default=(),
             help='Comma separated internal names import of which must not be reported.\n'
                  'Accepts full path (module.sub_module._name) or plain name (_name).\n'
-                 'If full path used then only that name from that module would be skipped.\n'
+                 'If full path used then only that specific name from that specific module would be skipped.\n'
                  'If plain name used then name would be skipped independent on module it imported from.'
         )
         add_option(
@@ -177,24 +150,24 @@ class Plugin:
             help='When option used, relative imports will not be reported'
         )
 
-    @classmethod
-    def parse_options(cls, options: argparse.Namespace) -> None:
-        """parse options and save them in class' attributes"""
-        cls.skip_relative = options.internal_name_import_skip_relative
-        cls.skip_local = options.internal_name_import_skip_local
+    @staticmethod
+    def parse_options(options: argparse.Namespace) -> None:
+        """Parse options and save them in Visitor's attributes"""
+        Visitor.skip_relative = options.internal_name_import_skip_relative
+        Visitor.skip_local = options.internal_name_import_skip_local
 
-        cls.skip_modules = set(options.internal_name_import_skip_modules)
-        cls.skip_from_modules = set(options.internal_name_import_skip_names_from_modules)
+        Visitor.skip_modules = set(options.internal_name_import_skip_modules)
+        Visitor.skip_from_modules = set(options.internal_name_import_skip_names_from_modules)
 
-        cls.global_skip_names = set()
-        cls.module_to_skip_names = {}
+        Visitor.global_skip_names = set()
+        Visitor.module_to_skip_names = {}
         for name in options.internal_name_import_skip_names:
             try:  # module.sub_module._name
                 module, name = name.split('.', maxsplit=1)
             except ValueError:  # _name
-                cls.global_skip_names.add(name)
+                Visitor.global_skip_names.add(name)
             else:
-                cls.module_to_skip_names.setdefault(module, set()).add(name)
+                Visitor.module_to_skip_names.setdefault(module, set()).add(name)
 
     def __init__(self, tree: ast.Module, filename: str) -> None:
         self.tree = tree
@@ -206,4 +179,14 @@ class Plugin:
 
         :return: Iterator of (line_number, column_number, report_message, plugin_type)
         """
-        yield from ((line_num, col_num, msg, type(self)) for line_num, col_num, msg in Visitor(self).run())
+        if self.TEST_PATH_PATTERN.search(self.file_name):
+            return
+
+        for report in self._iter_reports():
+            yield report.node.lineno, report.node.col_offset, report.full_message, type(self)
+
+    def _iter_reports(self) -> Iterator[INIXXX]:
+        """Encapsulates logic of running Visitor and getting reports"""
+        visitor = Visitor()
+        visitor.visit(self.tree)
+        yield from visitor.reports

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Visit github for codes, options and examples: https://github.com/rows-s/flake8_i
 
 setup(
     name='flake8_internal_name_import',
-    version='1.0.0',
+    version='1.0.1',
     description="flake8 plugin that reports imports of internal names",
     long_description=long_description,
     # Get more from https://pypi.org/classifiers/
@@ -49,7 +49,7 @@ setup(
     },
     entry_points={
         'flake8.extension': [
-            'PNI00 = flake8_internal_name_import:Plugin',
+            'INI00 = flake8_internal_name_import:Plugin',
         ],
     },
 )


### PR DESCRIPTION
Have found a way to not use self implemented AST-traversal and now use native NodeVisitor.
Local code if not skipped will be check without any restrictions on depth.
Improved documentation.